### PR TITLE
[FIX] double registration of the default namespace

### DIFF
--- a/docs/Namespaces_in_XML_Views_2421a2c.md
+++ b/docs/Namespaces_in_XML_Views_2421a2c.md
@@ -11,18 +11,18 @@ view on: [help.sap.com](https://help.sap.com/viewer/DRAFT/3237636b137e43519a20ad
 
 The names of the OpenUI5 control libraries and the related subpackages are mapped to XML namespaces.
 
-One of the required namespaces can be defined as the default namespace. The control tags for this namespace do not need a prefix.
+One of the required namespaces can be defined as the default namespace \(`xmlns="..."`\). The control tags for this namespace do not need a prefix.
 
-The `<View>` tag is required and in the example below, the `mvc` namespace is defined in the first line. You can define any alias for the namespace.
+The `View` tag is required and in the example below, the `sap.ui.core.mvc` namespace is defined with alias `mvc`. Technically, you can define any alias for namespaces. However, the convention is to use the last part of the full package name.
 
 A control can be located in a subpackage of a control library, for example `sap.ui.layout.form.Form` is located in the `sap.ui.layout` library, but the full package name is `sap.ui.layout.form`. You have to specify this subpackage as a separate XML namespace, even if `sap.ui.layout` is already defined as namespace.
 
 ```lang-xml
 <mvc:View
-   controllerName="..."
-   xmlns="sap.ui.layout"
-   xmlns="sap.ui.layout.form"
-   xmlns:mvc="sap.ui.core.mvc">
+	xmlns:mvc="sap.ui.core.mvc"
+	xmlns:layout="sap.ui.layout"
+	xmlns:form="sap.ui.layout.form"
+	xmlns="sap.m">
 </mvc:View>
 ```
 


### PR DESCRIPTION
* Fixes: https://github.com/SAP/openui5/issues/2294
* Replaced spaces with tabs for indentation according to the coding guideline
* Removed `controllerName="..."` as it's irrelevant to the topic