### PR TITLE
[FIX] Content Padding Classes: invalid quotation mark and class name

### DIFF
--- a/docs/Using_Container_Content_Padding_CSS_Classes_c71f6df.md
+++ b/docs/Using_Container_Content_Padding_CSS_Classes_c71f6df.md
@@ -49,7 +49,7 @@ The following list shows examples of controls that support container content pad
 
 ``` xml
 
-<Page class=”sapUiResponsivePadding”>
+<Page class="sapUiResponsiveContentPadding">
 ```
 
 ***


### PR DESCRIPTION
- The _right double quotation mark_ (`”`) is an invalid character to be used in XML when defining attribute values. Replacing it with a plain quotation mark (`"`)..
- The class name `sapUiResponsiveContent` is incomplete. Should be either `sapUiResponsiveContent--header`/ `--content`/ etc.. or one of the class names mentioned in the topic such as `sapUiResponsiveContentPadding`.