### PR TITLE
[FIX] Enabling Responsive Paddings: replaced sapM with sapUi

### DIFF
--- a/docs/Enabling_Responsive_Paddings_3b718b5.md
+++ b/docs/Enabling_Responsive_Paddings_3b718b5.md
@@ -60,10 +60,10 @@ Based on the container’s size, one of the following classes is added, and the 
 
 |Container Size \(pixels\)|Class|Padding-Left and Padding-Right Applied|
 |-------------------------|-----|--------------------------------------|
-|<= 600|sapM-Std-PaddingS|1rem|
-|\>600|sapM-Std-PaddingM|2rem|
-|\>1024|sapM-Std-PaddingL|2rem|
-|\>1440|sapM-Std-PaddingXL|3rem|
+|<= 600|sapUi-Std-PaddingS|1rem|
+|\>600|sapUi-Std-PaddingM|2rem|
+|\>1024|sapUi-Std-PaddingL|2rem|
+|\>1440|sapUi-Std-PaddingXL|3rem|
 
 ***
 


### PR DESCRIPTION
`sapM-Std-Padding*` is renamed to `sapUi-Std-Padding*`.

Fixes: https://github.com/SAP/openui5-docs/issues/21