### PR TITLE
Remove upperCase in group header factory snippet

### DIFF
--- a/docs/Sorting,_Grouping,_and_Filtering_for_List_Binding_ec79a5d.md
+++ b/docs/Sorting,_Grouping,_and_Filtering_for_List_Binding_ec79a5d.md
@@ -60,8 +60,7 @@ sap.ui.define([
 		
 		getGroupHeader: function(oGroup) {
 			return new GroupHeaderListItem({
-				title : oGroup.key,
-				upperCase : false
+				title : oGroup.key
 			}
 		);
 	},   


### PR DESCRIPTION
The property `upperCase` in sap.m.GroupHeaderListItem is [deprecated as of 1.40.10](https://github.com/SAP/openui5/blob/4a38f996653df39fa101aa9f22bc8dac8bff2356/src/sap.m/src/sap/m/GroupHeaderListItem.js#L58). Removing it to avoid encouraging use of it.