### PR TITLE
[FIX] Enabling Responsive Paddings: typo in sapUi-Std-Padding*

### DIFF
--- a/docs/Enabling_Responsive_Paddings_3b718b5.md
+++ b/docs/Enabling_Responsive_Paddings_3b718b5.md
@@ -33,10 +33,10 @@ Based on the container’s size, one of the following classes is added, and the 
 
 |Container Size \(pixels\)|Class|Padding-Left and Padding-Right Applied|
 |-------------------------|-----|--------------------------------------|
-|<= 600|sapUI-Std-PaddingS|1rem|
-|\>600|sapUI-Std-PaddingM|2rem|
-|\>1024|sapUI-Std-PaddingL|2rem|
-|\>1440|sapUI-Std-PaddingXL|3rem|
+|<= 600|sapUi-Std-PaddingS|1rem|
+|\>600|sapUi-Std-PaddingM|2rem|
+|\>1024|sapUi-Std-PaddingL|2rem|
+|\>1440|sapUi-Std-PaddingXL|3rem|
 
 ***
 


### PR DESCRIPTION
According to https://github.com/SAP/openui5/blob/f04a228210314c830302cdc02a1b96d76eb80368/src/sap.ui.core/src/sap/ui/core/util/ResponsivePaddingsEnablement.js#L28-L34, the `I` in the style class name needs to be in lower case. <del>`sapUI-Std-Padding*`</del> --> `sapUi-Std-Padding*`