### PR TITLE
Add a custom "404 - Page not found"

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -18,6 +18,8 @@
           coverpage: "coverpage.md",
           onlyCover: false,
           loadSidebar: "sidebar.md",
+          notFoundPage: true,
+          notFoundPage: '404.html',
           mergeNavbar: true,
           maxLevel: 0,
           subMaxLevel: 0,


### PR DESCRIPTION
We need to have a custom "Page not found" message as we have added an "edit in GitHub" button to each Demo Kit page and when Demo Kit and GitHub documentation pages are not identical it can be confusing if the GitHub version says it's just missing without some further explanation.
I tested if this is working on a forked version here: https://xtatica.github.io/openui5-docs/#/What's_New_in_OpenUI9ac68a