### PR TITLE
[FIX] Field Groups: removed "byFieldGroupId([])" from snippet

### DIFF
--- a/docs/Field_Groups_5b07753.md
+++ b/docs/Field_Groups_5b07753.md
@@ -76,7 +76,6 @@ Similar to the above you can use the `byFieldGroupId` method of `sap.ui.Core` to
 ```
 var aAllControlsWithFieldGroupId = sap.ui.getCore().byFieldGroupId();              //all where fieldGroupId is not empty 
 var aMyGroupControls             = sap.ui.getCore().byFieldGroupId("MyGroup");     //exact matches to myGroup 
-var aNotGrouped                  = sap.ui.getCore().byFieldGroupId([]);            //exact empty array (default value of fieldGroupIds)
 ```
 
 ***


### PR DESCRIPTION
Passing an empty array (`Core.byFieldGroupId([])`) returns **all** registered controls within the Core. It does not differentiate whether a control has field group ID or not. See https://github.com/SAP/openui5/issues/2377#issuecomment-475569549.

The variable name `var aNotGrouped` is therefore incorrect.
Since the behavior didn't match with the description above the snippet, the line is now removed.

Fixes: https://github.com/SAP/openui5/issues/2377