### PR TITLE
Update webapp/view/App.view.xml - Correction

### DIFF
--- a/docs/Step_6_Resource_Models_9790d9a.md
+++ b/docs/Step_6_Resource_Models_9790d9a.md
@@ -106,7 +106,7 @@ Language-specific text stored in resource models obeys the Java convention for i
 <mvc:View
 	xmlns="sap.m"
 	xmlns:mvc="sap.ui.core.mvc">
-	<Panel headerText="*HIGHLIGHT START*i18n>*HIGHLIGHT END*panelHeaderText}" class="sapUiResponsiveMargin" width="auto">
+	<Panel headerText="*HIGHLIGHT START*{i18n>*HIGHLIGHT END*panelHeaderText}" class="sapUiResponsiveMargin" width="auto">
 		<content>
 			<Label text="*HIGHLIGHT START*{i18n>firstName}*HIGHLIGHT END*" class="sapUiSmallMargin"/>
 			<Input value="{/firstName}" valueLiveUpdate="true" width="200px" enabled="{/enabled}"/>


### PR DESCRIPTION
Hi there,
Please make below correction in <Panel> element. 
'{' was missing before 'i18n>' in the value for attribute headerText which is mapped to resource model property panelHeaderText.

Correct code should be as below:
*HIGHLIGHT START***{**i18n>*HIGHLIGHT END*

![2020-04-14_21-34-00](https://user-images.githubusercontent.com/52113122/79247425-217a1880-7e98-11ea-8138-5d9d55ff30fa.jpg)
