### PR TITLE
Wrong Label for Amount/Currency Property in models

### DIFF
--- a/docs/Step_10_Property_Formatting_Using_Data_Types_9252ee4.md
+++ b/docs/Step_10_Property_Formatting_Using_Data_Types_9252ee4.md
@@ -52,7 +52,7 @@ sap.ui.require([
 				zip: "69190",
 				country: "Germany"
 			}*HIGHLIGHT START*,
-			"salesToDate" : 12345.6789,
+			"salesAmount" : 12345.6789,
 			"currencyCode" : "EUR"
 *HIGHLIGHT END*
 		});
@@ -113,7 +113,7 @@ We create two new model properties `salesToDate` and `currencyCode`.
 					<Input width="200px" enabled="{/enabled}" description="{/currencyCode}"
 						value="{
 							parts: [
-								{path: '/salesToDate'},
+								{path: '/salesAmount'},
 								{path: '/currencyCode'}
 							],
 							type: 'sap.ui.model.type.Currency',
@@ -138,7 +138,7 @@ firstName=Vorname
 lastName=Nachname
 enabled=Enabled
 address=Address
-*HIGHLIGHT START*salesToDate=Sales to Date*HIGHLIGHT END*...
+*HIGHLIGHT START*salesAmount=Sales to Date*HIGHLIGHT END*...
 ```
 
 ***
@@ -151,7 +151,7 @@ firstName=Vorname
 lastName=Nachname
 enabled=Aktiviert
 address=Adresse
-*HIGHLIGHT START*salesToDate=Verk\\u00e4ufe bis zum heutigen Datum*HIGHLIGHT END*
+*HIGHLIGHT START*salesAmount=Verk\\u00e4ufe bis zum heutigen Datum*HIGHLIGHT END*
 ...
 ```
 


### PR DESCRIPTION
The new property in the model (both JSON and Resource) is an amount field, which is formatted according to the currency. But its label has been mentioned as ' salesToDate' suggesting it to be a date property which is inappropriate. It should have been something like 'salesAmount' or 'salesValue'.

Existing label 'saleToDate' creates a confusion as how can Currency data type be used to format a date value.  