### PR TITLE
Fix comment indent

### DIFF
--- a/docs/Extending_Input_Rendering_bcee26a.md
+++ b/docs/Extending_Input_Rendering_bcee26a.md
@@ -19,7 +19,7 @@ The control API and the `render` method can be inherited as it is and the `rende
 ``` js
   
 sap.m.Input.extend("HighlightInput", {// call the new Control type "HighlightInput" 
-								// and let it inherit from sap.m.Input
+                                      // and let it inherit from sap.m.Input
 
 			renderer: {
 				// note that no render() function is given here. The Input's render() function is used. 
@@ -27,10 +27,10 @@ sap.m.Input.extend("HighlightInput", {// call the new Control type "HighlightInp
 
 				writeInnerAttributes : function(oRm, oInput) {
 					sap.m.InputRenderer.writeInnerAttributes.apply(this, arguments); // the default method should be called
-																		 // this will make sure that all default input attributes will be there
+					                                                                 // this will make sure that all default input attributes will be there
 
 					oRm.addStyle('background-color', '#ffff00');  // this change could also be done with plain CSS. 
-														  // But you get the idea...
+					                                              // But you get the idea...
 					  }
 				  }
 			  });


### PR DESCRIPTION
Due to tabs being used for indent instead of spaces the comments are not aligned and vary a lot between being displayed at

* https://openui5.hana.ondemand.com/topic/bcee26a4801748f39bf5698d83d903aa
* https://sap.github.io/openui5-docs/#/Extending_Input_Rendering_bcee26a.md
* https://github.com/SAP/openui5-docs/blob/master/docs/Extending_Input_Rendering_bcee26a.md
* https://github.com/SAP/openui5-docs/edit/master/docs/Extending_Input_Rendering_bcee26a.md

In no instance are they aligned correctly, across lines.

This change keeps the prefix indent as tabs to be consistent with the file overall but changes the comment-line alignment to spaces which shifts them according to the statement they comment and to be correctly aligned with the other lines the comment belongs to.