### PR TITLE
Added missing highlighting for 'Locale' dependency

### DIFF
--- a/docs/Step_15_Writing_a_Short_Date_Formatter_Using_TDD_bc4114a.md
+++ b/docs/Step_15_Writing_a_Short_Date_Formatter_Using_TDD_bc4114a.md
@@ -139,8 +139,8 @@ Now we fix our test again by returning the expected string.
 
 ``` js
 sap.ui.define([
-	"sap/ui/demo/bulletinboard/model/DateFormatter",
-	"sap/ui/core/Locale"
+	"sap/ui/demo/bulletinboard/model/DateFormatter"*HIGHLIGHT START*,
+	"sap/ui/core/Locale"*HIGHLIGHT END*
 ], function(DateFormatter, Locale) {
 	QUnit.module("DateFormatter");
 	QUnit.test("Should return empty string if no date is given", function(assert) {


### PR DESCRIPTION
As I was going through it I kind of missed out on the dependency the first time as it wasn't highlighted like all the other code changes (incl. their dependencies).

Just a very minor change that does help reading through it (in my opinion).