### PR TITLE
[FIX] JS Guidelines: added notation for Promises

### DIFF
--- a/docs/JavaScript_Coding_Guidelines_eded636.md
+++ b/docs/JavaScript_Coding_Guidelines_eded636.md
@@ -86,6 +86,7 @@ When using the Hungarian notation, use the prefixes highlighted below and contin
 |**f**Decimal|float|
 |**b**Enabled|boolean|
 |**r**Pattern|RegExp|
+|**p**Pending|Promise|
 |**fn**Function|function|
 |**v**Variant|variant types|
 


### PR DESCRIPTION
The Hungarian notation for `Promise` instances was missing in the table _Naming Conventions_.
This led to a misunderstanding that the `pDialog` in Walkthrough tutorials was a typo.

Fixes: https://github.com/SAP/openui5/issues/3060