### PR TITLE
Minor visual fix for supported library combinations

### DIFF
--- a/docs/Supported_Library_Combinations_363cd16.md
+++ b/docs/Supported_Library_Combinations_363cd16.md
@@ -16,7 +16,7 @@ OpenUI5 provides a set of JavaScript and CSS libraries, which can be combined in
 
 In general, most library combinations are supported. However, restrictions apply for the following libraries:
 
--   `sap.ui.commons (deprecated)`
+-   `sap.ui.commons` \(deprecated\)
 
 -   `sap.ui.suite`
 


### PR DESCRIPTION
To be consistent with rest of the page, since the "(deprecated)" is not something technical and should therefore not be in the code tags.