### PR TITLE
[FIX] Replace `core:View` with `mvc:View`

### DIFF
--- a/docs/Resource_Model_91f122a.md
+++ b/docs/Resource_Model_91f122a.md
@@ -78,14 +78,15 @@ The `ResourceModel` required for binding these texts is created during view inst
 2.  To bind this resource bundle content in XML views, insert the following code:
 
     ```xml
-    <core:View resourceBundleName="myBundle"
-               resourceBundleAlias="i18n" 
-               controllerName="sap.hcm.Address" xmlns="sap.m" xmlns:core="sap.ui.core"
-               xmlns:html="http://www.w3.org/1999/xhtml">
-       <Panel>
-          <Button text="{i18n>MY_TEXT}"/>
-       </Panel>
-    <core:View>
+    <mvc:View resourceBundleName="myBundle"
+      resourceBundleAlias="i18n" 
+      controllerName="sap.hcm.Address"
+      xmlns="sap.m"
+      xmlns:mvc="sap.ui.core.mvc">
+      <Panel>
+        <Button text="{i18n>MY_TEXT}"/>
+      </Panel>
+    <mvc:View>
     ```
 
 

--- a/docs/Semantic_Page_sap_f_47dc868.md
+++ b/docs/Semantic_Page_sap_f_47dc868.md
@@ -130,14 +130,14 @@ The left side contains the `messagesIndicator`, and the right side - `draftIndic
 Definition in an XML view:
 
 ```xml
-<core:View
-		xmlns:semantic="sap.f.semantic"
-			controllerName="mycompany.myController"
-			height="100%">
+<mvc:View xmlns:mvc="sap.ui.core.mvc"
+	xmlns:semantic="sap.f.semantic"
+	controllerName="mycompany.myController"
+	height="100%">
 	<semantic:SemanticPage id="mySemanticPage">
-		<!—semantic  page content specified  here -->
-	</semantic:SemanticPage >
-</core:View>
+		<!-- Semantic  page content specified here -->
+	</semantic:SemanticPage>
+</mvc:View>
 ```
 
 Definition in JavaScript:


### PR DESCRIPTION
Some XMLView defintion snippets contain `core:View` which is wrong. Should be replaced with `mvc:View`.  
See also https://github.com/SAP/ui5-language-assistant/issues/462#issuecomment-1193296891