### PR TITLE
[FIX] "Compatibility Rules" section "Inheritance"

### DIFF
--- a/docs/Compatibility_Rules_91f0873.md
+++ b/docs/Compatibility_Rules_91f0873.md
@@ -99,15 +99,14 @@ The following changes to existing APIs are incompatible, but **can be done in a 
 
 ### Inheritance
 
-Inheriting from OpenUI5 objects \(e.g. by calling `sap.ui.extend` on an existing control to add custom functionality\) may endanger the updatability of your code.
+Inheriting from OpenUI5 objects \(e.g. by calling `extend` on a control class to add custom functionality\) may endanger the updatability of your code.
 
 When overriding an OpenUI5 lifecycle method \(such as `init`, `exit`, `onBeforeRendering`, and `onAfterRendering`\), you must make sure that the super class implementation is called, for example like this:
 
 ```
 MyClass.prototype.onAfterRendering = function() {
-  SuperClass.prototype.onAfterRendering.apply(this);
-
-  // do your additional stuff AFTER calling super class
+  SuperClass.prototype.onAfterRendering.apply(this, arguments);
+  // ...
 }
 ```
 


### PR DESCRIPTION
- `sap.ui.extend` doesn't exist.
- `arguments` (e.g. event object or constructor settings) should be also passed when calling a method from the super prototypal method.
- Removed the comment "do your additional stuff AFTER calling super class" since the order depends on the nature of the method. E.g. the custom `exit` implementation should be rather processed BEFORE calling the standard `SuperClass.prototype.exit.apply(this, arguments)`.