### PR TITLE
"Declarative API for Initial Components": Incorporate event names that contain upper-case characters

### DIFF
--- a/docs/Declarative_API_for_Initial_Components_82a0fce.md
+++ b/docs/Declarative_API_for_Initial_Components_82a0fce.md
@@ -54,11 +54,11 @@ This module scans the DOM for HTML elements containing a special data attribute 
 ### Declarative Configuration of `ComponentContainer`
 
 > ### Caution:  
-> As HTML is case-insensitive, in order to define a property with upper-case characters you have to "escape" them with the hyphen character. This is similar to CSS attributes. In the following sample the `handleValidation` argument of the `ComponentContainer` constructor is used:
+> As HTML is case-insensitive, property or event names with upper-case characters have to be "escaped" with the hyphen character. This is similar to CSS attributes. In the following sample, the `handleValidation` and `componentCreated` arguments of the `ComponentContainer` constructor are used:
 > 
 > ```html
 > 
-> <div data-sap-ui-component ... data-handle-validation="true" ...></div>
+> <div data-sap-ui-component ... data-handle-validation="true" data-component-created="onComponentCreated"></div>
 > 
 > ```
 


### PR DESCRIPTION
When reading https://github.com/SAP/openui5-docs/blob/2824595ca980d568fe40c383e51216f09335a5f9/docs/Declarative_API_for_Initial_Components_82a0fce.md, it is not clear how an event handler can be attached in HTML.

Sample use: get notified when the component gets created by assigning a global handler to the `ComponentContainer`'s `componentCreated` event in the HTML document.

Related Q&A: https://stackoverflow.com/q/76587625/5846045