### PR TITLE
docs: Add missing space between class specifiers in Step 14 of Tutorial

### DIFF
--- a/docs/03_Get-Started/step-14-custom-css-and-theme-colors-723f4b2.md
+++ b/docs/03_Get-Started/step-14-custom-css-and-theme-colors-723f4b2.md
@@ -106,7 +106,7 @@ In the `resources` section of the `sap.ui5` namespace, additional resources for 
 									width="60%"/>
 								<FormattedText
 									htmlText="Hello {/recipient/name}"
-									class="sapUiSmallMarginmyCustomText"/>
+									class="sapUiSmallMargin myCustomText"/>
 							</content>
 						</Panel>
 					</content>

--- a/docs/03_Get-Started/step-14-custom-css-and-theme-colors-typescript-4cc841e.md
+++ b/docs/03_Get-Started/step-14-custom-css-and-theme-colors-typescript-4cc841e.md
@@ -112,7 +112,7 @@ The actual color now depends on the selected theme, which ensures that the color
                                     width="60%"/>
                                 <FormattedText
                                     htmlText="Hello {/recipient/name}"
-                                    class="sapUiSmallMarginmyCustomText"/>
+                                    class="sapUiSmallMargin myCustomText"/>
                             </content>
                         </Panel>
                     </content>


### PR DESCRIPTION
Added a missing space between class specifiers in the FormattedText tag in the XML View in step 14 of both the JS and TS tutorial.

<img width="847" height="660" alt="image" src="https://github.com/user-attachments/assets/b29df34c-ecd0-4849-b8d4-43e560f659f7" />
